### PR TITLE
fix(theme): improve contrast of buttons

### DIFF
--- a/src/bricks/theme/theme.css
+++ b/src/bricks/theme/theme.css
@@ -209,7 +209,7 @@ textarea {
   background: 0 0;
   line-height: 1;
   font-size: 0.8rem;
-  font-family: 'Raleway', sans-serif;
+  font-family: sans-serif;
 }
 select[multiple],
 textarea {


### PR DESCRIPTION
Raleway is a very thin font which doesn't provide good contrast in small font sizes, so the buttons are hardly readable. Use the default sans-serif font as for all other items.

Compare before:
![e92e28f4-f417-11ea-9256-507b9d024c54](https://user-images.githubusercontent.com/192014/92911352-1ae0d480-f429-11ea-9b5b-7d17d63a6346.png)

and after:
![fb88d7ce-f417-11ea-a328-507b9d024c54](https://user-images.githubusercontent.com/192014/92911406-2502d300-f429-11ea-98e9-3dbc397fedca.png)
