### PR TITLE
implement random sounds after a transaction

### DIFF
--- a/public/sound-config.json
+++ b/public/sound-config.json
@@ -1,0 +1,3 @@
+{
+  "sounds":["ka-ching.wav"]
+}

--- a/src/services/sound.ts
+++ b/src/services/sound.ts
@@ -1,11 +1,28 @@
 import { Howl } from 'howler';
 import { CreateTransactionParams } from '../store/reducers';
 
-const dispense = new Howl({
-  src: ['ka-ching.wav'],
-});
+const howls: Howl[] = [];
+fetch('sound-config.json')
+  .then(response => {
+    if (response.status == 404) {
+      throw Error('file "sound-config.json" not found');
+    }
+    return response.json()
+  })
+  .then(config => {
+    const sounds = config['sounds'];
+    for (let i=0; i<sounds.length; i++) {
+      howls.push(new Howl({
+        src: [sounds[i]]
+      }));
+    }
+  })
+  .catch(err => {
+    console.error('Error while handling sound-config', err);
+  });
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function playCashSound(_params?: CreateTransactionParams): void {
-  dispense.play();
+  const sound = howls[Math.floor(Math.random() * howls.length)];
+  sound.play();
 }


### PR DESCRIPTION
# Context
We @nerdbergev wanted the strichliste to play different sounds after purchasing an item. This is the result of my quick attempt to implement the feature. I'm not that advanced at web development though so feel free to tell me if I need to change anything.

# Feature
The default is still only the 'ka-ching' sound. To add more sounds you need
to place your sound files next to the `ka-ching.wav` file and then add the
filename to the sounds in the `sounds-config.json` file.
E.g. (sounds-config.json):
```json
{
    "sounds":["ka-ching.wav", "mario-coin.wav"]
}
```