### PR TITLE
also match at position 0

### DIFF
--- a/src/services/error-handler.ts
+++ b/src/services/error-handler.ts
@@ -8,7 +8,7 @@ function handleApiError(
   error: { class: string }
 ): void {
   const [key] = Object.keys(config.errors || {}).filter(key =>
-    error.class.indexOf(key)
+    error.class.includes(key)
   );
 
   if (key && config.errors && config.errors[key]) {


### PR DESCRIPTION
This worked since the php exceptions start with `App\\Exception\\`. We shouldn't rely on this though.