### PR TITLE
feature(article-selection-bubbles): display recent items of a user instead of globally popular ones 

### DIFF
--- a/src/components/article/article-selection-bubbles.tsx
+++ b/src/components/article/article-selection-bubbles.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-import { usePopularArticles } from '../../store';
-import { Article, startLoadingArticles } from '../../store/reducers';
+import { usePopularArticles, useUserRecentArticles } from '../../store';
+import { Article, startLoadingArticles, startLoadingUserDetails, startLoadingUsers } from '../../store/reducers';
 import { Currency } from '../currency';
 import { ArticleValidator } from './validator';
 import { Flex, Input, CancelButton, Button } from '../../bricks';
@@ -16,14 +16,29 @@ interface Props {
 
 const ARTICLE_BUBBLE_LIMIT = 10;
 export const ArticleSelectionBubbles = (props: Props) => {
-  const items = usePopularArticles();
   const dispatch = useDispatch();
   const intl = useIntl();
   const [query, setQuery] = React.useState('');
 
+  const allItemsSortedByPopularity = usePopularArticles();
+  const recentItemsPickedByUser = useUserRecentArticles(props.userId);
+  let itemsToShow = [];
+
+  if (!query) {
+    itemsToShow = recentItemsPickedByUser;
+  } else {
+    itemsToShow = allItemsSortedByPopularity.filter((item) =>
+      item.name.toLowerCase().includes(query.toLowerCase())
+    );
+  }
+  itemsToShow.slice(0, ARTICLE_BUBBLE_LIMIT);
+
   React.useEffect(() => {
     startLoadingArticles(dispatch, true);
   }, [dispatch]);
+  React.useEffect(() => {
+    startLoadingUserDetails(dispatch, props.userId);
+  }, [dispatch, props.userId]);
 
   return (
     <div>
@@ -36,7 +51,7 @@ export const ArticleSelectionBubbles = (props: Props) => {
         <CancelButton margin="0 0 0 1rem" onClick={props.onCancel} />
       </Flex>
       <Flex margin="2rem 0 0 0" flexWrap="wrap" justifyContent="center">
-        {items
+        {itemsToShow
           .filter(
             (item) =>
               !query || item.name.toLowerCase().includes(query.toLowerCase())

--- a/src/store/reducers/user.ts
+++ b/src/store/reducers/user.ts
@@ -1,4 +1,5 @@
-import { Transaction, TransactionTypes } from '.';
+import { Transaction, TransactionTypes, getTransaction } from '.';
+import { Article } from '.';
 import { Action } from '..';
 import { get, post } from '../../services/api';
 import { errorHandler } from '../../services/error-handler';
@@ -246,4 +247,25 @@ export function getUserTransactionsArray(
   } else {
     return [];
   }
+}
+
+export function getUserRecentArticles(
+  state: AppState,
+  userId: string
+): Article[] {
+  const TRANSACTIONS_TO_SCAN_FOR_RECENT_ARTICLES_LIMIT = 30;
+  const recentUserArticlesWithDuplicates = getUserTransactionsArray(state, userId)
+    .slice(0, TRANSACTIONS_TO_SCAN_FOR_RECENT_ARTICLES_LIMIT) 
+    .map((id) => getTransaction(state, id))
+    .map((transaction) => transaction?.article)
+    .filter((article): article is Article => article !== undefined);
+
+  const userRecentArticles = new Map<string, Article>();
+  recentUserArticlesWithDuplicates.forEach((article) => {
+    if (!userRecentArticles.has(article.name)) {
+      userRecentArticles.set(article.name, article);
+    }
+  });
+
+  return Array.from(userRecentArticles.values());
 }

--- a/src/store/selector-hooks.ts
+++ b/src/store/selector-hooks.ts
@@ -7,6 +7,7 @@ import {
   getArticleList,
   getPayPal,
   getPopularArticles,
+  getUserRecentArticles,
   getSettings,
   getUser,
   getUserArray,
@@ -57,6 +58,14 @@ export function useActiveArticles(isActive: boolean): Article[] {
 
 export function usePopularArticles(): Article[] {
   return useSelector<AppState, Article[]>(getPopularArticles);
+}
+
+export function useUserRecentArticles(userId: string): Article[] {
+  return useSelector<AppState, Article[]>(
+    useCallback((state: AppState) => getUserRecentArticles(state, userId), [
+      userId,
+    ])
+  );
 }
 
 export function useArticle(id: number | undefined) {


### PR DESCRIPTION
Hello,

as a user, I **always** have to manually search for my item, since it is not one of the most popular items globally.
Therefore, I added a feature that shows users' recent items as selection bubbles, while still presenting globally popular items as suggestions when users search for items.

Let me know what you think about it :)

BR
Michael