### PR TITLE
feat(currency): enable setting custom currency signs via configuration

### DIFF
--- a/src/components/currency/currency.tsx
+++ b/src/components/currency/currency.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/style-prop-object */
 
 import * as React from 'react';
-import { FormattedNumber } from 'react-intl';
+import { FormattedNumberParts } from 'react-intl';
+import { useSettings } from '../../store';
 
 interface Props {
   value: number;
@@ -9,10 +10,32 @@ interface Props {
 }
 
 export function Currency({ value, hidePlusSign }: Props): JSX.Element {
+  const settings = useSettings();
+  const customCurrencySign = settings.i18n.currency.symbol;
+
   return (
     <>
       {value > 0 && !hidePlusSign ? '+' : ''}
-      <FormattedNumber currency="EUR" value={value / 100} style="currency" />
+      <FormattedNumberParts
+        value={value / 100}
+        style={'currency'}
+        currency={'EUR'}
+        children={function (
+          parts: Intl.NumberFormatPart[]
+        ): React.ReactElement | null {
+          return (
+            <>
+              {parts.map((part) => {
+                if ((part.type === 'currency') && customCurrencySign) {
+                  return <>{customCurrencySign}</>;
+                } else {
+                  return <>{part.value}</>;
+                }
+              })}
+            </>
+          );
+        }}
+      />
     </>
   );
 }


### PR DESCRIPTION
Hello,

currently it is not possible to set a custom currency sign. This enables setting the sign via strichliste.yaml > i18n > currency > symbol

Closes #218 

BR
Michael