### PR TITLE
fix: align history package with react-router v5 requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "classnames": "^2.2.6",
-    "history": "^5.0.0",
+    "history": "^4.10.1",
     "howler": "^2.2.0",
     "inter-ui": "^3.15.0",
     "jest-environment-jsdom-sixteen": "^1.0.3",

--- a/src/components/article/article-edit-form-view.tsx
+++ b/src/components/article/article-edit-form-view.tsx
@@ -12,7 +12,7 @@ export function ArticleEditFormView({
     <>
       <div style={{ margin: '1rem' }}>
         <Button
-          onClick={() => history.back()}
+          onClick={() => history.goBack()}
           children={
             <>
               <Arrow
@@ -30,7 +30,7 @@ export function ArticleEditFormView({
       </div>
       <div style={{ padding: '1rem' }}>
         <ArticleForm
-          onCreated={history.back}
+          onCreated={() => history.goBack()}
           articleId={Number(match.params.id)}
         />
       </div>

--- a/src/components/article/article-form.tsx
+++ b/src/components/article/article-form.tsx
@@ -350,7 +350,7 @@ const ToggleActivity: React.FC<{ article: Article }> = ({ article }) => {
   const handleDeleteArticle = async () => {
     const res = await startDeletingArticle(dispatch, article.id);
     if (res) {
-      history.back();
+      history.goBack();
     }
   };
 

--- a/src/components/common/back-button.tsx
+++ b/src/components/common/back-button.tsx
@@ -5,7 +5,7 @@ import { Button } from '../../bricks';
 
 function NavButton(props: RouteComponentProps): JSX.Element | null {
   return (
-    <Button onClick={() => props.history.back()}>
+    <Button onClick={() => props.history.goBack()}>
       <FormattedMessage id="BACK_BUTTON" />
     </Button>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -961,7 +961,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.7.6":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -6052,7 +6052,7 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-history@^4.9.0:
+history@^4.10.1, history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
   integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
@@ -6063,13 +6063,6 @@ history@^4.9.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
-
-history@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/history/-/history-5.0.0.tgz#0cabbb6c4bbf835addb874f8259f6d25101efd08"
-  integrity sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==
-  dependencies:
-    "@babel/runtime" "^7.7.6"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Hello :)

It's now my second PR, but first one in this frontend repo.

## Description

Downgrade history from ^5.0.0 to ^4.10.1 to fix version mismatch.

Because react-router v5 expects history v4 API (goBack/goForward), but history v5 renamed these methods (back/forward). -> This caused navigation failures.

## What this PR does

- Downgrade history to v4.10.1 (compatible with react-router v5)
- Replace history.back() with history.goBack() in all components

## Notes:

`yarn list` shows the history version from react-router as `^4.9.0` which works with the version in this PR:
```
├─ react-router@5.2.0
│  ├─ @babel/runtime@^7.1.2
│  ├─ history@^4.9.0
```