### PR TITLE
Fix/improve error handling when adding tags/barcodes

### DIFF
--- a/src/components/article/article-form.tsx
+++ b/src/components/article/article-form.tsx
@@ -165,6 +165,8 @@ const ArticleBarCodes: React.FC<{ article: Article }> = ({ article }) => {
     const response = await startAddBarcode(dispatch, article.id, barcode);
     if (response) {
       setBarcodes(response.barcodes);
+    } else {
+      setBarcodes(barcodes.filter((item) => item.id !== 0));
     }
   };
   const handleDeleteBarcode = async (barcode: Barcode) => {
@@ -195,6 +197,8 @@ const ArticleTags: React.FC<{ article: Article }> = ({ article }) => {
     const response = await startAddTag(dispatch, article.id, tag);
     if (response) {
       setTags(response.tags);
+    } else {
+      setTags(tags.filter((item) => item.id !== 0));
     }
   };
   const handleDeleteTag = async (tag: Tag) => {

--- a/src/components/common/scanner.tsx
+++ b/src/components/common/scanner.tsx
@@ -40,7 +40,7 @@ export class Scanner extends React.Component<Props, State> {
       if (this.props.onChange) {
         this.props.onChange(this.state.barcode);
       }
-    } else if (/[a-zA-Z0-9]/i.test(key)) {
+    } else if (key.length === 1 && /[a-zA-Z0-9]/.test(key) && !event.ctrlKey && !event.altKey && !event.metaKey) {
       this.setState(state => ({
         barcode: '',
         maybeBarcode: state.maybeBarcode + key,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -32,6 +32,11 @@ export const en = {
     'Could not create the article maybe check your internet connection',
   ARTICLE_COULD_NOT_BE_LOADED_BY_BARCODE:
     'Could not load the article by barcode',
+  ARTICLE_BARCODE_ALREADY_EXISTS:
+    'This barcode is already assigned to an article',
+  ARTICLE_BARCODE_COULD_NOT_BE_ADDED: 'Could not add the barcode',
+  ARTICLE_TAG_ALREADY_EXISTS: 'This tag is already assigned to this article',
+  ARTICLE_TAG_COULD_NOT_BE_ADDED: 'Could not add the tag',
   TALLY_HEADER: 'Strichliste',
   USERS_LOADING_FAILED:
     'Oops could not load users :-( Maybe check your internet connection and try it again',

--- a/src/store/reducers/article.ts
+++ b/src/store/reducers/article.ts
@@ -73,6 +73,10 @@ export async function startAddBarcode(
   const promise = post(`article/${id}/barcode`, { barcode });
   const data = await errorHandler<any>(dispatch, {
     promise,
+    defaultError: 'ARTICLE_BARCODE_COULD_NOT_BE_ADDED',
+    errors: {
+      ArticleBarcodeAlreadyExistsException: 'ARTICLE_BARCODE_ALREADY_EXISTS',
+    },
   });
   if (data && data.article) {
     return data.article;
@@ -104,6 +108,10 @@ export async function startAddTag(
   const promise = post(`article/${id}/tag`, { tag });
   const data = await errorHandler<any>(dispatch, {
     promise,
+    defaultError: 'ARTICLE_TAG_COULD_NOT_BE_ADDED',
+    errors: {
+      ArticleTagAlreadyExistsException: 'ARTICLE_TAG_ALREADY_EXISTS',
+    },
   });
   if (data && data.article) {
     return data.article;


### PR DESCRIPTION
Some small frontend fixes/improvments for https://github.com/strichliste/strichliste-backend/pull/95

- Article Edit: Show error message when adding tag/barcode failed
- Article Edit: Revert to the correct state if adding tag/barcode failed
- Scanner: Ignore multi-character key names like "Enter" (they were accepted before because they fit the regex)
- Scanner: Ignore keys when a modifier is pressed (e.g. `Ctrl+C`)