### PR TITLE
Prevent barcode scanner Enter from re-triggering focused button

### DIFF
--- a/src/components/common/scanner.tsx
+++ b/src/components/common/scanner.tsx
@@ -28,6 +28,7 @@ export class Scanner extends React.Component<Props, State> {
   }
 
   public detection = (event: KeyboardEvent): void => {
+    if (event.repeat) return;
     const key = event.key;
 
     clearTimeout(this.state.timeout);

--- a/src/components/common/scanner.tsx
+++ b/src/components/common/scanner.tsx
@@ -20,11 +20,11 @@ export class Scanner extends React.Component<Props, State> {
   public inputRef = React.createRef<HTMLInputElement>();
 
   public componentDidMount(): void {
-    document.addEventListener('keyup', this.detection);
+    document.addEventListener('keydown', this.detection);
   }
 
   public componentWillUnmount(): void {
-    document.removeEventListener('keyup', this.detection);
+    document.removeEventListener('keydown', this.detection);
   }
 
   public detection = (event: KeyboardEvent): void => {
@@ -33,6 +33,7 @@ export class Scanner extends React.Component<Props, State> {
     clearTimeout(this.state.timeout);
 
     if (key === 'Enter' && this.state.maybeBarcode.length > 6) {
+      event.preventDefault();
       this.setState(state => ({
         barcode: state.maybeBarcode,
         maybeBarcode: '',


### PR DESCRIPTION
Fixes a rather subtle bug: Open a user, click on a button (e.g. add money). Then scan a barcode. The article will be bought (if barcode exists), but also the button will be activated again (by the "Enter" from the scanner) because it is still focused.

Least invasive fix seems to be to listen on `keydown` instead of `keyup` and stop the event (pressed "Enter" key) from propagating if we have scanned a barcode.

Note: Navigating the UI with Tab and pressing "Enter" still works - Enter is **only** suppressed when a barcode is scanned.