### PR TITLE
Make inputs for existing barcodes/tags readonly

### DIFF
--- a/src/bricks/input/input.module.css
+++ b/src/bricks/input/input.module.css
@@ -11,6 +11,11 @@
   color: var(--textSubtile);
 }
 
+.input:read-only {
+  opacity: 0.6;
+  cursor: default;
+}
+
 .formField {
   margin-bottom: 1rem;
 }

--- a/src/components/article/article-form.tsx
+++ b/src/components/article/article-form.tsx
@@ -277,9 +277,7 @@ const ListInput: React.FC<{
     <form
       onSubmit={(e) => {
         e.preventDefault();
-        if (item) {
-          handleRemove(item);
-        } else {
+        if (!item) {
           handleAdd(value);
         }
       }}
@@ -289,12 +287,14 @@ const ListInput: React.FC<{
           placeholder={placeholder}
           autoFocus={item === ''}
           value={value}
+          readOnly={!!item}
           onChange={(e) => setValue(e.target.value)}
         />
         {item ? (
           <CancelButton
             title={intl.formatMessage({ id: 'DELETE_ITEM' })}
-            type="submit"
+            type="button"
+            onClick={() => handleRemove(item)}
             margin="0 0 0 0.5rem"
           />
         ) : (


### PR DESCRIPTION
Right now, existing barcodes and tags can be modified in the input field. If Enter is pressed, the tag/barcode is removed. Editing tags/barcodes is not supported, so make the input for existing tags/barcodes readonly. Also prevent deleting a tag/barcode by focussing the (readonly) input and pressing Enter.