### PR TITLE
Use i18n settings (alpha3, language) from backend for currency rendering

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -13,6 +13,7 @@ import { SplitInvoiceForm } from './components/transaction';
 import { startLoadingSettings } from './store/reducers';
 import { store } from './store';
 import { UserRouter } from './components/user/user-router';
+import { useSettings } from './store/selector-hooks';
 
 // tslint:disable-next-line:no-import-side-effect
 import 'inter-ui';
@@ -75,15 +76,32 @@ const Layout = () => {
   );
 };
 
+const LocalizedIntlProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { i18n } = useSettings();
+  return (
+    <IntlProvider
+      textComponent={React.Fragment}
+      locale={i18n.language}
+      messages={en}
+    >
+      {children}
+    </IntlProvider>
+  );
+};
+
 export const App = () => {
   return (
     <ThemeProvider>
       <Provider store={store}>
-        <IntlProvider textComponent={React.Fragment} locale="en" messages={en}>
+        <LocalizedIntlProvider>
           <HashRouter hashType="hashbang">
             <Layout />
           </HashRouter>
-        </IntlProvider>
+        </LocalizedIntlProvider>
       </Provider>
     </ThemeProvider>
   );

--- a/src/components/currency/__tests__/currency.spec.tsx
+++ b/src/components/currency/__tests__/currency.spec.tsx
@@ -1,33 +1,27 @@
 import * as React from 'react';
-import { cleanup, render } from '@testing-library/react';
+import { cleanup } from '@testing-library/react';
 
-import { IntlProvider } from 'react-intl';
 import { Currency } from '../';
+import { renderWithContext } from '../../../spec-configs/render';
 
 afterEach(cleanup);
 
 describe('Currency', () => {
   it('matches the snapshot for english locales', () => {
-    const { container } = render(
-      <IntlProvider defaultLocale="en">
-        <Currency value={120} />
-      </IntlProvider>
-    );
+    const { container } = renderWithContext(<Currency value={120} />, {});
     expect(container).toMatchSnapshot();
   });
   it('hides plus icons by prop', () => {
-    const { container } = render(
-      <IntlProvider defaultLocale="en">
-        <Currency hidePlusSign value={120} />
-      </IntlProvider>
+    const { container } = renderWithContext(
+      <Currency hidePlusSign value={120} />,
+      {}
     );
     expect(container).toMatchSnapshot();
   });
   it('show - icons', () => {
-    const { container } = render(
-      <IntlProvider defaultLocale="en">
-        <Currency hidePlusSign value={-120} />
-      </IntlProvider>
+    const { container } = renderWithContext(
+      <Currency hidePlusSign value={-120} />,
+      {}
     );
     expect(container).toMatchSnapshot();
   });

--- a/src/components/currency/currency.tsx
+++ b/src/components/currency/currency.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { FormattedNumber } from 'react-intl';
+import { useSettings } from '../../store/selector-hooks';
 
 interface Props {
   value: number;
@@ -9,10 +10,15 @@ interface Props {
 }
 
 export function Currency({ value, hidePlusSign }: Props): JSX.Element {
+  const { i18n } = useSettings();
   return (
     <>
       {value > 0 && !hidePlusSign ? '+' : ''}
-      <FormattedNumber currency="EUR" value={value / 100} style="currency" />
+      <FormattedNumber
+        currency={i18n.currency.alpha3}
+        value={value / 100}
+        style="currency"
+      />
     </>
   );
 }


### PR DESCRIPTION
Right now, the `i18n` settings on the backend do nothing. We could use `i18n.currency.alpha3` and `i18n.currcany.language` to localize the currency formatting. The symbol is chosen automatically by the `IntlProvider`, so I dont know what to do with `i18n.currency.symbol` - maybe just remove it from the config file.

Closes #218


Current rendering (equal to "en/EUR"):
<img width="254" height="242" alt="image" src="https://github.com/user-attachments/assets/582a0e48-a0d2-42c4-8765-778515a63827" />


Example for "de/EUR":
<img width="254" height="242" alt="image" src="https://github.com/user-attachments/assets/9b3dbaff-f4cb-4f98-85f4-d0d2602b5a1a" />


Example for "en/USD":
<img width="254" height="242" alt="image" src="https://github.com/user-attachments/assets/92bb6524-cf90-461d-91b1-ae7fc160d3e8" />

